### PR TITLE
remove parallel_llama for now

### DIFF
--- a/data/runs.json
+++ b/data/runs.json
@@ -678,56 +678,5 @@
     "wandb_link": "https://wandb.ai/held/marin/runs/olmo_50m_gpu_1xH200_run-65d630",
     "run_completion_timestamp": "2025-05-21 04:46:21 UTC",
     "description": "50M param model based on OLMo architecture."
-  },
-  {
-    "run_name": "parallel_llama/150m",
-    "results_filepath": "experiments/speedrun/parallel_llama/150m",
-    "author": {
-      "name": "Harry Shin",
-      "affiliation": "Independent",
-      "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
-    },
-    "model_size": 154147328,
-    "training_hardware_flops": 9.264161724167268e+18,
-    "training_time": 9362.46763432771,
-    "model_flops": 1.707084418797011e+18,
-    "eval_paloma_c4_en_bpb": 1.230665683746338,
-    "wandb_link": "https://wandb.ai/dh2shin2-stanford-university/marin/runs/parallel_llama_150m_20250927_214314-6b5619",
-    "run_completion_timestamp": "2025-09-28 00:49:27 UTC",
-    "description": "Parallel Llama ~150M with parallel attention/MLP computation."
-  },
-  {
-    "run_name": "parallel_llama/300m",
-    "results_filepath": "experiments/speedrun/parallel_llama/300m",
-    "author": {
-      "name": "Harry Shin",
-      "affiliation": "Independent",
-      "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
-    },
-    "model_size": 299649792,
-    "training_hardware_flops": 3.704721641930257e+19,
-    "training_time": 37440.33998918906,
-    "model_flops": 7.92805570191242e+18,
-    "eval_paloma_c4_en_bpb": 1.1177308559417725,
-    "wandb_link": "https://wandb.ai/dh2shin2-stanford-university/marin/runs/parallel_llama_300m_20250928_005125-5ab6f2",
-    "run_completion_timestamp": "2025-09-28 12:47:30 UTC",
-    "description": "Parallel Llama ~300M with parallel attention/MLP computation."
-  },
-  {
-    "run_name": "parallel_llama/75m",
-    "results_filepath": "experiments/speedrun/parallel_llama/75m",
-    "author": {
-      "name": "Harry Shin",
-      "affiliation": "Independent",
-      "url": "https://www.linkedin.com/in/harry-shin-34743216a/"
-    },
-    "model_size": 73273600,
-    "training_hardware_flops": 3.296863581757771e+18,
-    "training_time": 3331.8479856066406,
-    "model_flops": 4.0210928652150374e+17,
-    "eval_paloma_c4_en_bpb": 1.3113893270492554,
-    "wandb_link": "https://wandb.ai/dh2shin2-stanford-university/marin/runs/parallel_llama_75m_1024-4ba3f3",
-    "run_completion_timestamp": "2025-09-25 04:14:50 UTC",
-    "description": "Parallel Llama ~75M with parallel attention/MLP computation."
   }
 ]


### PR DESCRIPTION
Getting errors on the speedrun page

```
ValueError: operands could not be broadcast together with shapes (3,) (4,)
Traceback (most recent call last):
  Cell 
marimo://notebook.py#cell=render_speedrun_plot
, line 58, in <module>
    g["eval_paloma_c4_en_bpb"].values
ValueError: operands could not be broadcast together with shapes (3,) (4,) 
```

and rather suspecting it is because parallel_llama currently only has 3 runs