### PR TITLE
Change link to readthedocs version of submitting-speedrun, instead of the GH markdown file

### DIFF
--- a/website/src/components/Introduction.tsx
+++ b/website/src/components/Introduction.tsx
@@ -4,7 +4,7 @@ export function Introduction() {
       <div className="flex flex-col md:flex-row justify-between items-start gap-4 mb-6">
         <h2 className="text-3xl text-gray-900">What is Speedrun?</h2>
         <a 
-          href="https://github.com/marin-community/marin/blob/main/docs/tutorials/submitting-speedrun.md" 
+          href="https://marin.readthedocs.io/en/latest/tutorials/submitting-speedrun/" 
           target="_blank" 
           rel="noopener noreferrer"
           className="inline-flex items-center px-6 py-3 border border-transparent rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-150 whitespace-nowrap"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the CTA link to point to the canonical documentation.
> 
> - Changes `href` in `Introduction.tsx` from the GitHub markdown file to `https://marin.readthedocs.io/en/latest/tutorials/submitting-speedrun/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54c1065d4ad530972eaf112fb44a4f6a9768ac75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->